### PR TITLE
Near-complete compensation for lack of async assets.

### DIFF
--- a/docs/js/p5.dom.js
+++ b/docs/js/p5.dom.js
@@ -1,7 +1,7 @@
 /*! p5.dom.js v0.1.3 September 2, 2014 */
 /**
- * <p>The web is much more than just canvas and p5.dom makes it easy to interact 
- * with other HTML5 objects, including text, hyperlink, image, input, video, 
+ * <p>The web is much more than just canvas and p5.dom makes it easy to interact
+ * with other HTML5 objects, including text, hyperlink, image, input, video,
  * audio, and webcam.</p>
  * <p>There are a set of creation methods, and some other stuff... @TODO.</p>
  *
@@ -31,7 +31,7 @@ var p5DOM = (function(){
    * Searches the page for an element with given ID and returns it as
    * a p5.Element. The DOM node itself can be accessed with .elt.
    * Returns null if none found.
-   * 
+   *
    * @method getElement
    * @param  {String} id id of element to search for
    * @return {Object/p5.Element|Null} p5.Element containing node found
@@ -49,7 +49,7 @@ var p5DOM = (function(){
    * Searches the page for elements with given class and returns an
    * array of p5.Elements. The DOM nodes themselves can be accessed
    * with .elt. Returns an empty array if none found.
-   * 
+   *
    * @method getElements
    * @param  {String} class class name of elements to search for
    * @return {Array} array of p5.Element wrapped nodes found
@@ -83,7 +83,7 @@ var p5DOM = (function(){
 
   /**
    * Helpers for create methods.
-   */  
+   */
   function addElement(elt, pInst, media) {
     var node = pInst._userNode ? pInst._userNode : document.body;
     node.appendChild(elt);
@@ -94,9 +94,9 @@ var p5DOM = (function(){
 
   /**
    * Creates a &lt;div&gt;&lt;/div&gt; element in the DOM with given inner HTML.
-   * Appends to the container node if one is specified, otherwise 
+   * Appends to the container node if one is specified, otherwise
    * appends to body.
-   * 
+   *
    * @method createDiv
    * @param  {String} html inner HTML for element created
    * @return {Object/p5.Element} pointer to p5.Element holding created
@@ -106,9 +106,9 @@ var p5DOM = (function(){
   /**
    * Creates a &lt;p&gt;&lt;/p&gt; element in the DOM with given inner HTML. Used
    * for paragraph length text.
-   * Appends to the container node if one is specified, otherwise 
+   * Appends to the container node if one is specified, otherwise
    * appends to body.
-   * 
+   *
    * @method createP
    * @param  {String} html inner HTML for element created
    * @return {Object/p5.Element} pointer to p5.Element holding created
@@ -117,9 +117,9 @@ var p5DOM = (function(){
 
   /**
    * Creates a &lt;span&gt;&lt;/span&gt; element in the DOM with given inner HTML.
-   * Appends to the container node if one is specified, otherwise 
+   * Appends to the container node if one is specified, otherwise
    * appends to body.
-   * 
+   *
    * @method createSpan
    * @param  {String} html inner HTML for element created
    * @return {Object/p5.Element} pointer to p5.Element holding created
@@ -137,10 +137,10 @@ var p5DOM = (function(){
 
   /**
    * Creates an &lt;img /&gt; element in the DOM with given src and
-   * alternate text. 
-   * Appends to the container node if one is specified, otherwise 
+   * alternate text.
+   * Appends to the container node if one is specified, otherwise
    * appends to body.
-   * 
+   *
    * @method createImg
    * @param  {String} src src path or url for image
    * @param  {String} alt alternate text to be used if image does not
@@ -160,9 +160,9 @@ var p5DOM = (function(){
 
   /**
    * Creates an &lt;a&gt;&lt;/a&gt; element in the DOM for including a hyperlink.
-   * Appends to the container node if one is specified, otherwise 
+   * Appends to the container node if one is specified, otherwise
    * appends to body.
-   * 
+   *
    * @method createA
    * @param  {String} href       url of page to link to
    * @param  {String} html       inner html of link element to display
@@ -185,9 +185,9 @@ var p5DOM = (function(){
   /**
    * Creates a slider &lt;input&gt;&lt;/input&gt; element in the DOM.
    * Use .size() to set the display length of the slider.
-   * Appends to the container node if one is specified, otherwise 
+   * Appends to the container node if one is specified, otherwise
    * appends to body.
-   * 
+   *
    * @method createSlider
    * @param  {Number} min minimum value of the slider
    * @param  {Number} max maximum value of the slider
@@ -208,9 +208,9 @@ var p5DOM = (function(){
    * Creates a &lt;button&gt;&lt;/button&gt; element in the DOM.
    * Use .size() to set the display size of the button.
    * Use .mousePressed() to specify behavior on press.
-   * Appends to the container node if one is specified, otherwise 
+   * Appends to the container node if one is specified, otherwise
    * appends to body.
-   * 
+   *
    * @method createButton
    * @param  {String} label label displayed on the button
    * @param  {String} [value] value of the button
@@ -228,9 +228,9 @@ var p5DOM = (function(){
   /**
    * Creates an &lt;input&gt;&lt;/input&gt; element in the DOM for text input.
    * Use .size() to set the display length of the box.
-   * Appends to the container node if one is specified, otherwise 
+   * Appends to the container node if one is specified, otherwise
    * appends to body.
-   * 
+   *
    * @method createInput
    * @param  {Number} [value] default value of the input box
    * @return {Object/p5.Element} pointer to p5.Element holding created
@@ -255,11 +255,6 @@ var p5DOM = (function(){
       source.src = src[i];
       elt.appendChild(source);
     }
-    if (typeof callback !== 'undefined') {
-      elt.addEventListener('canplaythrough', function() {
-        callback();
-      });
-    }
 
     var c = addElement(elt, pInst, true);
     c.loadedmetadata = false;
@@ -269,23 +264,34 @@ var p5DOM = (function(){
       c.height = elt.videoHeight;
       c.loadedmetadata = true;
     });
-    
-    return c;  
+
+    // track if the video buffer has enough data to play
+    if (type === 'video') {
+      c.loadedVideoData = false;
+      elt.addEventListener('canplaythrough', function() {
+        if (typeof callback !== 'undefined') {
+          callback();
+        }
+        c.loadedVideoData = true;
+      });
+    }
+
+    return c;
   }
   /**
    * Creates an HTML5 &lt;video&gt; element in the DOM for simple playback
    * of audio/video. Shown by default, can be hidden with .hide()
    * and drawn into canvas using video(). Appends to the container
    * node if one is specified, otherwise appends to body.
-   * 
+   *
    * @method createVideo
    * @param  {String|Array} src  path to a video file, or array of paths for
    *                             supporting different browsers
-   * @param  {Object} [callback] callback function to be called upon 
+   * @param  {Object} [callback] callback function to be called upon
    *                             'canplaythrough' event fire, that is, when the
-   *                             browser can play the media, and estimates that 
-   *                             enough data has been loaded to play the media 
-   *                             up to its end without having to stop for 
+   *                             browser can play the media, and estimates that
+   *                             enough data has been loaded to play the media
+   *                             up to its end without having to stop for
    *                             further buffering of content
    * @return {Object/p5.Element} pointer to video p5.Element
    */
@@ -296,18 +302,18 @@ var p5DOM = (function(){
   /** AUDIO STUFF **/
 
   /**
-   * Creates a hidden HTML5 &lt;audio&gt; element in the DOM for simple audio 
-   * playback. Appends to the container node if one is specified, 
+   * Creates a hidden HTML5 &lt;audio&gt; element in the DOM for simple audio
+   * playback. Appends to the container node if one is specified,
    * otherwise appends to body.
-   * 
+   *
    * @method createAudio
    * @param  {String|Array} src  path to an audio file, or array of paths for
    *                             supporting different browsers
-   * @param  {Object} [callback] callback function to be called upon 
+   * @param  {Object} [callback] callback function to be called upon
    *                             'canplaythrough' event fire, that is, when the
-   *                             browser can play the media, and estimates that 
-   *                             enough data has been loaded to play the media 
-   *                             up to its end without having to stop for 
+   *                             browser can play the media, and estimates that
+   *                             enough data has been loaded to play the media
+   *                             up to its end without having to stop for
    *                             further buffering of content
    * @return {Object/p5.Element} pointer to audio p5.Element
    */
@@ -317,7 +323,7 @@ var p5DOM = (function(){
 
 
   /** CAMERA STUFF **/
-  
+
   p5.prototype.VIDEO = 'video';
   p5.prototype.AUDIO = 'audio';
 
@@ -331,7 +337,7 @@ var p5DOM = (function(){
    * from a webcam. This can be drawn onto the canvas using video().
    *
    * @method createCapture
-   * @param  {String/Constant}   type type of capture, either VIDEO or 
+   * @param  {String/Constant}   type type of capture, either VIDEO or
    *                             AUDIO if none specified, default both
    * @return {Object/p5.Element} capture video p5.Element
    */
@@ -360,12 +366,12 @@ var p5DOM = (function(){
 
   /**
    * Creates element with given tag in the DOM with given content.
-   * Appends to the container node if one is specified, otherwise 
+   * Appends to the container node if one is specified, otherwise
    * appends to body.
-   * 
+   *
    * @method createElement
    * @param  {String} tag tag for the new element
-   * @param  {String} [content] html content to be inserted into the element 
+   * @param  {String} [content] html content to be inserted into the element
    * @return {Object/p5.Element} pointer to p5.Element holding created
    *                           node
    */
@@ -427,7 +433,7 @@ var p5DOM = (function(){
    * @method child
    * @param  {String|Object} child the ID or node to add to the current element
    * @return {p5.Element}
-   */ 
+   */
   p5.Element.prototype.child = function(c) {
     if (typeof c === 'string') {
       c = document.getElementById(c);
@@ -439,7 +445,7 @@ var p5DOM = (function(){
 
   /**
    *
-   * If an argument is given, sets the inner HTML of the element, 
+   * If an argument is given, sets the inner HTML of the element,
    * replacing any existing html. If no arguments are given, returns
    * the inner HTML of the element.
    *
@@ -479,7 +485,7 @@ var p5DOM = (function(){
   /**
    *
    * Sets the given style (css) property of the element with the given value.
-   * If no value is specified, returns the value of the given property, 
+   * If no value is specified, returns the value of the given property,
    * or undefined if the property is not.
    *
    * @method style
@@ -513,14 +519,14 @@ var p5DOM = (function(){
 
   /**
    *
-   * Adds a new attribute or changes the value of an existing attribute 
+   * Adds a new attribute or changes the value of an existing attribute
    * on the specified element. If no value is specified, returns the
    * value of the given attribute, or null if attribute is not set.
    *
    * @method attribute
    * @param  {String} attr       attribute to set
    * @param  {String} [value]    value to assign to attribute
-   * @return {String|p5.Element} value of attribute, if no value is 
+   * @return {String|p5.Element} value of attribute, if no value is
    *                             specified or p5.Element
    * @example
    * <div class="norender"><code>
@@ -541,10 +547,10 @@ var p5DOM = (function(){
   /**
    * Either returns the value of the element if no arguments
    * given, or sets the value of the element.
-   * 
+   *
    * @method value
    * @param  {String|Number}     [value]
-   * @return {String|p5.Element} value of element, if no value is 
+   * @return {String|p5.Element} value of element, if no value is
    *                             specified or p5.Element
    */
   p5.Element.prototype.value = function() {
@@ -560,9 +566,9 @@ var p5DOM = (function(){
   };
 
   /**
-   * 
+   *
    * Shows the current element. Essentially, setting display:block for the style.
-   * 
+   *
    * @method show
    * @return {p5.Element}
    */
@@ -573,7 +579,7 @@ var p5DOM = (function(){
 
   /**
    * Hides the current element. Essentially, setting display:none for the style.
-   * 
+   *
    * @method hide
    * @return {p5.Element}
    */
@@ -583,10 +589,10 @@ var p5DOM = (function(){
   };
 
   /**
-   * 
+   *
    * Sets the width and height of the element. AUTO can be used to
    * only adjust one dimension.
-   * 
+   *
    * @method size
    * @param  {Number} w width of the element
    * @param  {Number} h height of the element
@@ -606,7 +612,7 @@ var p5DOM = (function(){
       // set diff for cnv vs normal div
       if (this.elt instanceof HTMLCanvasElement) {
         var j = {};
-        var k  = this.elt.getContext('2d');        
+        var k  = this.elt.getContext('2d');
         for (var prop in k) {
           j[prop] = k[prop];
         }
@@ -635,7 +641,7 @@ var p5DOM = (function(){
 
   /**
    * Removes the element and deregisters all listeners.
-   * 
+   *
    * @method remove
    */
   p5.Element.prototype.remove = function() {
@@ -677,7 +683,7 @@ var p5DOM = (function(){
 
   /**
    * Play an HTML5 media element.
-   * 
+   *
    * @method play
    * @return {p5.Element}
    */
@@ -687,11 +693,11 @@ var p5DOM = (function(){
     }
     this.elt.play();
     return this;
-  };  
+  };
 
   /**
    * Stops an HTML5 media element (sets current time to zero).
-   * 
+   *
    * @method stop
    * @return {p5.Element}
    */
@@ -699,22 +705,22 @@ var p5DOM = (function(){
     this.elt.pause();
     this.elt.currentTime = 0;
     return this;
-  };  
+  };
 
   /**
    * Pauses an HTML5 media element.
-   * 
+   *
    * @method pause
    * @return {p5.Element}
    */
   p5.MediaElement.prototype.pause = function() {
     this.elt.pause();
     return this;
-  };  
+  };
 
   /**
    * Set 'loop' to true for an HTML5 media element, and starts playing.
-   * 
+   *
    * @method loop
    * @return {p5.Element}
    */
@@ -726,7 +732,7 @@ var p5DOM = (function(){
   /**
    * Set 'loop' to false for an HTML5 media element. Element will stop
    * when it reaches the end.
-   * 
+   *
    * @method noLoop
    * @return {p5.Element}
    */
@@ -738,7 +744,7 @@ var p5DOM = (function(){
 
   /**
    * Set HTML5 media element to autoplay or not.
-   * 
+   *
    * @method autoplay
    * @param {Boolean} autoplay whether the element should autoplay
    * @return {p5.Element}
@@ -751,7 +757,7 @@ var p5DOM = (function(){
   /**
    * Sets volume for this HTML5 media element. If no argument is given,
    * returns the current volume.
-   * 
+   *
    * @param {Number}            [val] volume between 0.0 and 1.0
    * @return {Number|p5.MediaElement} current volume or p5.MediaElement
    * @method volume
@@ -767,7 +773,7 @@ var p5DOM = (function(){
   /**
    * If no arguments are given, returns the current time of the elmeent.
    * If an argument is given the current time of the element is set to it.
-   * 
+   *
    * @method time
    * @param {Number} [time] time to jump to (in seconds)
    * @return {Number|p5.MediaElement} current time (in seconds)
@@ -783,7 +789,7 @@ var p5DOM = (function(){
 
   /**
    * Returns the duration of the HTML5 media element.
-   * 
+   *
    * @method duration
    * @return {Number} duration
    */

--- a/lib/addons/p5.dom.js
+++ b/lib/addons/p5.dom.js
@@ -38,11 +38,11 @@
 // =============================================================================
 
   /**
-   * Searches the page for an element with the given ID, class, or tag name (using the '#' or '.' 
+   * Searches the page for an element with the given ID, class, or tag name (using the '#' or '.'
    * prefixes to specify an ID or class respectively, and none for a tag) and returns it as
-   * a p5.Element. If a class or tag name is given with more than 1 element, 
+   * a p5.Element. If a class or tag name is given with more than 1 element,
    * only the first element will be returned.
-   * The DOM node itself can be accessed with .elt. 
+   * The DOM node itself can be accessed with .elt.
    * Returns null if none found.
    *
    * @method select
@@ -75,14 +75,14 @@
       }else {
         return null;
       }
-    } 
+    }
   };
 
   /**
-   * Searches the page for elements with the given class or tag name (using the '.' prefix 
-   * to specify a class and no prefix for a tag) and returns them as p5.Elements 
-   * in an array. 
-   * The DOM node itself can be accessed with .elt. 
+   * Searches the page for elements with the given class or tag name (using the '.' prefix
+   * to specify a class and no prefix for a tag) and returns them as p5.Elements
+   * in an array.
+   * The DOM node itself can be accessed with .elt.
    * Returns null if none found.
    *
    * @method selectAll
@@ -404,13 +404,13 @@
   };
 
   /**
-   * Creates an &lt;input&gt;&lt;/input&gt; element in the DOM of type 'file'.  
+   * Creates an &lt;input&gt;&lt;/input&gt; element in the DOM of type 'file'.
    * This allows users to select local files for use in a sketch.
-   * 
+   *
    * @method createFileInput
    * @param  {Function} [callback] callback function for when a file loaded
    * @param  {String} [multiple] optional to allow multiple files selected
-   * @return {Object/p5.Element} pointer to p5.Element holding created DOM element                       
+   * @return {Object/p5.Element} pointer to p5.Element holding created DOM element
    */
   p5.prototype.createFileInput = function(callback, multiple) {
 
@@ -426,7 +426,7 @@
         // Anything gets the job done
         elt.multiple = 'multiple';
       }
-     
+
       // Now let's handle when a file was selected
       elt.addEventListener('change', handleFileSelect, false);
 
@@ -449,7 +449,7 @@
               callback(p5file);
             };
           };
-          
+
           // Text of data?
           // This should likely be improved
           if (f.type === 'text') {
@@ -478,11 +478,6 @@
       source.src = src[i];
       elt.appendChild(source);
     }
-    if (typeof callback !== 'undefined') {
-      elt.addEventListener('canplaythrough', function() {
-        callback();
-      });
-    }
 
     var c = addElement(elt, pInst, true);
     c.loadedmetadata = false;
@@ -492,6 +487,32 @@
       c.height = elt.videoHeight;
       c.loadedmetadata = true;
     });
+
+    // track if the video buffer has enough data to play
+    if (type === 'video') {
+      c.loadedVideoData = false;
+
+      // NOTE: hack in canvas for what should be in "p5.Video.js"
+      c.canvas = document.createElement('canvas');
+      c.canvas.width = c.width;
+      c.canvas.height = c.height;
+      c.drawingContext = c.canvas.getContext('2d');
+      c.drawingContext.fillRect(0, 0, c.width, c.height);
+      elt.addEventListener('canplaythrough', function() {
+        if (typeof callback !== 'undefined') {
+          callback();
+        }
+        c.loadedVideoData = true;
+      });
+
+      // TODO: replace redraw of video to canvas with timer that is faster
+      // than the native 'timeupdate' <video> event fire rate
+      elt.addEventListener('timeupdate', function () {
+        if (c.loadedVideoData) {
+          c.drawingContext.drawImage(elt, 0, 0, c.width, c.height);
+        }
+      })
+    }
 
     return c;
   }
@@ -563,8 +584,8 @@
    * Creates a new &lt;video&gt; element that contains the audio/video feed
    * from a webcam. This can be drawn onto the canvas using video(). More
    * specific properties of the stream can be passing in a Constraints object.
-   * See the 
-   * <a href="http://w3c.github.io/mediacapture-main/getusermedia.html">W3C 
+   * See the
+   * <a href="http://w3c.github.io/mediacapture-main/getusermedia.html">W3C
    * spec</a> for possible properties. Note that not all of these are supported
    * by all browsers.
    *
@@ -1276,7 +1297,7 @@
    *  p5.sound object. If no element is provided, connects to p5's master
    *  output. That connection is established when this method is first called.
    *  All connections are removed by the .disconnect() method.
-   *  
+   *
    *  This method is meant to be used with the p5.sound.js addon library.
    *
    *  @method  connect
@@ -1288,7 +1309,7 @@
 
     // if p5.sound exists, same audio context
     if (typeof p5.prototype.getAudioContext === 'function') {
-      audioContext = p5.prototype.getAudioContext(); 
+      audioContext = p5.prototype.getAudioContext();
       masterOutput = p5.soundOut.input;
     } else {
       try {
@@ -1327,7 +1348,7 @@
    *  Disconnect all Web Audio routing, including to master output.
    *  This is useful if you want to re-route the output through
    *  audio effects, for example.
-   *  
+   *
    *  @method  disconnect
    */
   p5.MediaElement.prototype.disconnect = function() {
@@ -1354,7 +1375,7 @@
 
   /**
    *  Hide the default mediaElement controls.
-   *  
+   *
    *  @method hideControls
    */
   p5.MediaElement.prototype.hideControls = function() {
@@ -1395,7 +1416,7 @@
    *  <div><code>
    *  function setup() {
    *    background(255,255,255);
-   *    
+   *
    *    audioEl = createAudio('assets/beat.mp3');
    *    audioEl.showControls();
    *
@@ -1539,7 +1560,7 @@
      * @property size
      */
     this.size = file.size;
-    
+
     // Data not loaded yet
     this.data = undefined;
   };

--- a/src/3d/p5.Renderer3D.js
+++ b/src/3d/p5.Renderer3D.js
@@ -187,21 +187,35 @@ p5.Renderer3D.prototype.getLocation = function(shaderProgram, immediateMode) {
   //@TODO: figure out a better way instead of if statement
   if(immediateMode === undefined){
     //vertex normal Attribute
-    shaderProgram.vertexNormalAttribute =
+    var vertexNormalAttribLocation =
       gl.getAttribLocation(shaderProgram, 'aNormal');
-    gl.enableVertexAttribArray(shaderProgram.vertexNormalAttribute);
+    shaderProgram.vertexNormalAttribute = vertexNormalAttribLocation;
+    if (vertexNormalAttribLocation !== -1) {
+
+      gl.enableVertexAttribArray(shaderProgram.vertexNormalAttribute);
+    }
 
     //normal Matrix uniform
-    shaderProgram.uNMatrixUniform =
-    gl.getUniformLocation(shaderProgram, 'uNormalMatrix');
+    var uNormalMatrixLocation =
+      gl.getUniformLocation(shaderProgram, 'uNormalMatrix');
+    if (uNormalMatrixLocation !== -1) {
+      shaderProgram.uNMatrixUniform = uNormalMatrixLocation;
+    }
 
     //texture coordinate Attribute
-    shaderProgram.textureCoordAttribute =
+    var aTexCoordAttribLocation =
       gl.getAttribLocation(shaderProgram, 'aTexCoord');
-    gl.enableVertexAttribArray(shaderProgram.textureCoordAttribute);
+    shaderProgram.textureCoordAttribute = aTexCoordAttribLocation;
+    if (aTexCoordAttribLocation !== -1) {
 
-    shaderProgram.samplerUniform =
-    gl.getUniformLocation(shaderProgram, 'uSampler');
+      gl.enableVertexAttribArray(shaderProgram.textureCoordAttribute);
+    }
+
+    var samplerUniformLocation =
+      gl.getUniformLocation(shaderProgram, 'uSampler');
+    if (samplerUniformLocation !== -1) {
+      shaderProgram.samplerUniform = samplerUniformLocation;
+    }
   }
 };
 

--- a/src/3d/p5.Texture.js
+++ b/src/3d/p5.Texture.js
@@ -1,6 +1,6 @@
 /**
  * TODO WIP, SORRY!!
- * 
+ *
  */
 // 'use strict';
 
@@ -42,7 +42,7 @@
 //     //@TODO handle following cases:
 //     //- 2D canvas (p5 inst)
 //   }
-  
+
 //   if (this._isPowerOf2(image.width) && this._isPowerOf2(image.height)) {
 //     gl.generateMipmap(gl.TEXTURE_2D);
 //   } else {
@@ -67,7 +67,7 @@
 //  * https://www.opengl.org/wiki/NPOT_Texture
 //  * @param  {Number}  value
 //  * @return {Boolean}
- 
+
 // p5.Texture.prototype._isPowerOf2 = function(value){
 //   return (value & (value - 1)) === 0;
 // };

--- a/src/3d/retainedMode3D.js
+++ b/src/3d/retainedMode3D.js
@@ -31,26 +31,32 @@ p5.Renderer3D.prototype.initBuffer = function(gId, obj) {
 
   var shaderProgram = this.mHash[this.getCurShaderId()];
 
-  gl.bindBuffer(gl.ARRAY_BUFFER, this.gHash[gId].vertexBuffer);
-  gl.bufferData(
-    gl.ARRAY_BUFFER, new Float32Array(obj.vertices), gl.STATIC_DRAW);
-  gl.vertexAttribPointer(
-    shaderProgram.vertexPositionAttribute,
-    3, gl.FLOAT, false, 0, 0);
+  if (shaderProgram.vertexPositionAttribute !== -1) {
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.gHash[gId].vertexBuffer);
+    gl.bufferData(
+      gl.ARRAY_BUFFER, new Float32Array(obj.vertices), gl.STATIC_DRAW);
+    gl.vertexAttribPointer(
+      shaderProgram.vertexPositionAttribute,
+      3, gl.FLOAT, false, 0, 0);
+  }
 
-  gl.bindBuffer(gl.ARRAY_BUFFER, this.gHash[gId].normalBuffer);
-  gl.bufferData(
-    gl.ARRAY_BUFFER, new Float32Array(obj.vertexNormals), gl.STATIC_DRAW);
-  gl.vertexAttribPointer(
-    shaderProgram.vertexNormalAttribute,
-    3, gl.FLOAT, false, 0, 0);
+  if (shaderProgram.vertexNormalAttribute !== -1) {
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.gHash[gId].normalBuffer);
+    gl.bufferData(
+      gl.ARRAY_BUFFER, new Float32Array(obj.vertexNormals), gl.STATIC_DRAW);
+    gl.vertexAttribPointer(
+      shaderProgram.vertexNormalAttribute,
+      3, gl.FLOAT, false, 0, 0);
+  }
 
-  gl.bindBuffer(gl.ARRAY_BUFFER, this.gHash[gId].uvBuffer);
-  gl.bufferData(
-    gl.ARRAY_BUFFER, new Float32Array(obj.uvs), gl.STATIC_DRAW);
-  gl.vertexAttribPointer(
-    shaderProgram.textureCoordAttribute,
-    2, gl.FLOAT, false, 0, 0);
+  if (shaderProgram.textureCoordAttribute !== -1) {
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.gHash[gId].uvBuffer);
+    gl.bufferData(
+      gl.ARRAY_BUFFER, new Float32Array(obj.uvs), gl.STATIC_DRAW);
+    gl.vertexAttribPointer(
+      shaderProgram.textureCoordAttribute,
+      2, gl.FLOAT, false, 0, 0);
+  }
 
   gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.gHash[gId].indexBuffer);
   gl.bufferData
@@ -66,20 +72,26 @@ p5.Renderer3D.prototype.drawBuffer = function(gId) {
   var shaderKey = this.getCurShaderId();
   var shaderProgram = this.mHash[shaderKey];
 
-  gl.bindBuffer(gl.ARRAY_BUFFER, this.gHash[gId].vertexBuffer);
-  gl.vertexAttribPointer(
-    shaderProgram.vertexPositionAttribute,
-    3, gl.FLOAT, false, 0, 0);
+  if (shaderProgram.vertexPositionAttribute !== -1) {
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.gHash[gId].vertexBuffer);
+    gl.vertexAttribPointer(
+      shaderProgram.vertexPositionAttribute,
+      3, gl.FLOAT, false, 0, 0);
+  }
 
-  gl.bindBuffer(gl.ARRAY_BUFFER, this.gHash[gId].normalBuffer);
-  gl.vertexAttribPointer(
-    shaderProgram.vertexNormalAttribute,
-    3, gl.FLOAT, false, 0, 0);
+  if (shaderProgram.vertexNormalAttribute !== -1) {
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.gHash[gId].normalBuffer);
+    gl.vertexAttribPointer(
+      shaderProgram.vertexNormalAttribute,
+      3, gl.FLOAT, false, 0, 0);
+  }
 
-  gl.bindBuffer(gl.ARRAY_BUFFER, this.gHash[gId].uvBuffer);
-  gl.vertexAttribPointer(
-    shaderProgram.textureCoordAttribute,
-    2, gl.FLOAT, false, 0, 0);
+  if (shaderProgram.textureCoordAttribute !== -1) {
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.gHash[gId].uvBuffer);
+    gl.vertexAttribPointer(
+      shaderProgram.textureCoordAttribute,
+      2, gl.FLOAT, false, 0, 0);
+  }
 
   gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.gHash[gId].indexBuffer);
 


### PR DESCRIPTION
- current implementation of synchronous images and video
  no longer evoke lots of GL warnings.
- `texture()` only binds if media is completely loaded.
- media texture data uniformly loaded via <canvas> `context.getImageData()`
- video writes to dynamic context. this should be replaced
  with proper `p5.Video.js` in the future.
- dynamic video texture updates on `timeupdate` event,
  should replace this with something less spammy in the
  future (managed `setInterval()`?)
- **BONUS:** fixed shader warnings that dump at startup by only using
  attributes and uniforms if the `shaderProgram` has is ready
  and responds non-"-1" when queried for an attribute/uniform
  index.
- @indefinit apologies about the commit stripping trailing whitespace and making
  this diff confusing
